### PR TITLE
Update autoencoders.ipynb for latest TF version

### DIFF
--- a/autoencoders.ipynb
+++ b/autoencoders.ipynb
@@ -306,7 +306,7 @@
    ],
    "source": [
     "history = stacked_autoencoder.fit(x_train, x_train, epochs=10,\n",
-    "                                  validation_data=[x_test, x_test])"
+    "                                  validation_data=(x_test, x_test))"
    ]
   },
   {
@@ -418,7 +418,7 @@
     "\n",
     "subplot(1, 3, 3)\n",
     "pred = decoder.predict(latent_vector)\n",
-    "imshow(x_test[i], cmap=\"binary\")"
+    "imshow(pred.reshape((28, 28)), cmap=\"binary\")"
    ]
   },
   {
@@ -650,7 +650,7 @@
    ],
    "source": [
     "history = stacked_autoencoder.fit(x_train, x_train, epochs=10,\n",
-    "                         validation_data=[x_test, x_test])"
+    "                         validation_data=(x_test, x_test))"
    ]
   },
   {
@@ -1014,7 +1014,7 @@
    ],
    "source": [
     "history = stacked_autoencoder.fit(x_train_noise, x_train, epochs=10,\n",
-    "                                  validation_data=[x_test_noise, x_test])"
+    "                                  validation_data=(x_test_noise, x_test))"
    ]
   },
   {


### PR DESCRIPTION
Update script to work with the latest version of TF.

Looks like they updated it so that validation_data can't accept lists anymore. Also fixed 1 other random unimportant bug.

I have no idea how .ipynb files work, so I have no idea if this is the right way to propose changes. Sorry!